### PR TITLE
fix deadlock for destroy in recorder

### DIFF
--- a/apps/examples/cxxtest/MediaRecorder.cxx
+++ b/apps/examples/cxxtest/MediaRecorder.cxx
@@ -29,7 +29,7 @@ namespace Media
 	{
 		lock_guard<mutex> lock(*cMtx);
 
-		isRunning = false;
+		enqueue([this](){_destroy(); });
 		worker->join();
 		delete worker;
 
@@ -97,7 +97,7 @@ namespace Media
 	}
 
 	void MediaRecorder::_prepare()
-	{
+	{		
 		std::cout << "prepare recording" << std::endl;			
 	}
 
@@ -111,8 +111,15 @@ namespace Media
 		config.rate = sampleRate;
 		config.format = (pcm_format)pcmFormat;
 
+		//cardnum,  getDeviceCard
 		pcmIn = pcm_open(0, 0, PCM_IN, &config);		
 		cvStart.notify_one();
+	}
+
+	void MediaRecorder::_destroy()
+	{
+		std::cout << "destroy Recorder" << std::endl;
+		isRunning = false;
 	}
 
 	void MediaRecorder::_start()

--- a/apps/examples/cxxtest/MediaRecorder.hpp
+++ b/apps/examples/cxxtest/MediaRecorder.hpp
@@ -66,6 +66,7 @@ namespace Media
 		void _init();
 		void _prepare();
 		void _create();
+		void _destroy();
 		void _start();
 		void _pause();
 		void _stop();


### PR DESCRIPTION
call destroy immediately after calling Create,
a deadlock condition occurs.

Signed-off-by: jaesick.shin <jaesick.shin@samsung.com>