### PR TITLE
Add include guards in MediaRecorder header

### DIFF
--- a/apps/examples/cxxtest/MediaRecorder.hpp
+++ b/apps/examples/cxxtest/MediaRecorder.hpp
@@ -1,3 +1,6 @@
+#ifndef __MEIDAFRAMEWORK_MEDIARECORDER_HPP
+#define __MEIDAFRAMEWORK_MEDIARECORDER_HPP
+
 #include <thread>
 #include <mutex>
 #include <condition_variable>
@@ -89,3 +92,5 @@ namespace Media
 		int pcmFormat;
 	};
 }
+
+#endif


### PR DESCRIPTION
Add to prevent duplicate header include

Signed-off-by: jaesick.shin <jaesick.shin@samsung.com>