### PR TITLE
change rvalue to lvalue for media framework

### DIFF
--- a/apps/examples/cxxtest/MediaPlayer.cxx
+++ b/apps/examples/cxxtest/MediaPlayer.cxx
@@ -10,7 +10,7 @@ namespace Media
 		worker = nullptr;
 	}
 
-	player_result_t MediaPlayer::createWorker(unique_lock<mutex> &&lock)
+	player_result_t MediaPlayer::createWorker(unique_lock<mutex> &lock)
 	{
 		isRunning = true;		
 		worker = new thread(&MediaPlayer::worker_thread, this);
@@ -25,21 +25,21 @@ namespace Media
 	{
 		unique_lock<mutex> lock(*cMtx);
 		user_cb = nullptr;
-		return createWorker(std::move(lock));
+		return createWorker(lock);
 	}
 
 	player_result_t MediaPlayer::create(std::function<void(int, int)> &&_user_cb)
 	{
 		unique_lock<mutex> lock(*cMtx);
 		user_cb = std::move(_user_cb);
-		return createWorker(std::move(lock));
+		return createWorker(lock);
 	}
 
 	player_result_t MediaPlayer::create(std::function<void(int, int)> &_user_cb)
 	{
 		unique_lock<mutex> lock(*cMtx);
 		user_cb = _user_cb;
-		return createWorker(std::move(lock));
+		return createWorker(lock);
 	}
 
 	player_result_t MediaPlayer::destroy() // sync call

--- a/apps/examples/cxxtest/MediaPlayer.hpp
+++ b/apps/examples/cxxtest/MediaPlayer.hpp
@@ -67,7 +67,7 @@ namespace Media
 		thread *worker;
 		int worker_thread();
 
-		player_result_t createWorker(std::unique_lock<mutex> &&);
+		player_result_t createWorker(std::unique_lock<mutex> &);
 		void _create();
 		void _destroy();
 		void _prepare();

--- a/apps/examples/cxxtest/MediaRecorder.cxx
+++ b/apps/examples/cxxtest/MediaRecorder.cxx
@@ -7,7 +7,7 @@ namespace Media
 		_init();
 	}
 	
-	recorder_result_t MediaRecorder::createWorker(unique_lock<mutex> &&lock)
+	recorder_result_t MediaRecorder::createWorker(unique_lock<mutex> &lock)
 	{
 		isRunning = true;		
 		worker = new thread(&MediaRecorder::worker_thread, this);
@@ -23,21 +23,21 @@ namespace Media
 		unique_lock<mutex> lock(*cMtx);
 		std::cout << "create Recorder" << std::endl;
 		user_cb = nullptr;
-		return createWorker(std::move(lock));
+		return createWorker(lock);
 	}
 
 	recorder_result_t MediaRecorder::create(std::function<void(int, int)> &&_user_cb)
 	{
 		unique_lock<mutex> lock(*cMtx);
 		user_cb = std::move(_user_cb);
-		return createWorker(std::move(lock));
+		return createWorker(lock);
 	}
 
 	recorder_result_t MediaRecorder::create(std::function<void(int, int)> &_user_cb)
 	{
 		unique_lock<mutex> lock(*cMtx);
 		user_cb = _user_cb;
-		return createWorker(std::move(lock));
+		return createWorker(lock);
 	}
 
 	recorder_result_t MediaRecorder::destroy() // sync call

--- a/apps/examples/cxxtest/MediaRecorder.hpp
+++ b/apps/examples/cxxtest/MediaRecorder.hpp
@@ -68,7 +68,7 @@ namespace Media
 		thread *worker;
 		int worker_thread();
 
-		recorder_result_t createWorker(std::unique_lock<mutex> &&);
+		recorder_result_t createWorker(std::unique_lock<mutex> &);
 		void _init();
 		void _prepare();
 		void _unprepare();


### PR DESCRIPTION
not required rvalue(std::move)
so, change rvalue to lvalue for createWorker function

Signed-off-by: jaesick.shin <jaesick.shin@samsung.com>