### PR TITLE
Unprepare and destroy at destruction if needed

### DIFF
--- a/apps/examples/cxxtest/MediaPlayer.cxx
+++ b/apps/examples/cxxtest/MediaPlayer.cxx
@@ -208,6 +208,22 @@ namespace Media
 
 	MediaPlayer::~MediaPlayer()
 	{
+		player_result_t ret;
+
+		if (curState > PLAYER_STATE_IDLE) {
+			ret = unprepare();
+			if (ret != PLAYER_OK) {
+				std::cout << "MediaPlayer::unprepare FAILED" << std::endl;
+			}
+		}
+
+		if (curState == PLAYER_STATE_IDLE) {
+			ret = destroy();
+			if (ret != PLAYER_OK) {
+				std::cout << "MediaPlayer::destroy FAILED" << std::endl;
+			}
+		}
+
 		delete qMtx;
 		delete cMtx;
 	}


### PR DESCRIPTION
At destruction time, if current state is not PLAYER_STATE_NONE,
unprepare and destroy to make state PLAYER_STATE_NONE